### PR TITLE
feat: move deleted bookmarks to completed section

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -7,6 +7,8 @@ export const SETTING_IDS = {
 
 export const STORAGE_KEYS = {
   IMPORTED_IDS: 'remnote-raindrop-plugin_imported-highlight-ids',
+  HIGHLIGHT_ARTICLE_MAP: 'remnote-raindrop-plugin_highlight-article-map',
+  ARTICLE_REM_MAP: 'remnote-raindrop-plugin_article-rem-map',
   LAST_SYNC_TIME: 'remnote-raindrop-plugin_last-sync-time',
   SYNC_STATUS: 'remnote-raindrop-plugin_sync-status',
   SYNC_RESULT: 'remnote-raindrop-plugin_sync-result',
@@ -18,3 +20,4 @@ export const IMPORT_LOCATIONS = {
 } as const;
 
 export const RAINDROP_ARTICLES_REM_NAME = 'Raindrop Articles';
+export const COMPLETED_REM_NAME = 'Raindrop Articles — Completed';

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -7,8 +7,7 @@ export const SETTING_IDS = {
 
 export const STORAGE_KEYS = {
   IMPORTED_IDS: 'remnote-raindrop-plugin_imported-highlight-ids',
-  HIGHLIGHT_ARTICLE_MAP: 'remnote-raindrop-plugin_highlight-article-map',
-  ARTICLE_REM_MAP: 'remnote-raindrop-plugin_article-rem-map',
+  RAINDROP_REM_MAP: 'remnote-raindrop-plugin_raindrop-rem-map',
   LAST_SYNC_TIME: 'remnote-raindrop-plugin_last-sync-time',
   SYNC_STATUS: 'remnote-raindrop-plugin_sync-status',
   SYNC_RESULT: 'remnote-raindrop-plugin_sync-result',

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -20,4 +20,4 @@ export const IMPORT_LOCATIONS = {
 } as const;
 
 export const RAINDROP_ARTICLES_REM_NAME = 'Raindrop Articles';
-export const COMPLETED_REM_NAME = 'Raindrop Articles — Completed';
+export const COMPLETED_SECTION_NAME = 'Completed';

--- a/src/lib/raindrop-api.ts
+++ b/src/lib/raindrop-api.ts
@@ -1,4 +1,4 @@
-import { RaindropHighlight, HighlightsResponse } from './types';
+import { RaindropHighlight, HighlightsResponse, RaindropsResponse } from './types';
 
 const BASE_URL = 'https://api.raindrop.io/rest/v1';
 
@@ -58,4 +58,32 @@ export async function fetchAllHighlights(token: string): Promise<RaindropHighlig
   }
 
   return allHighlights;
+}
+
+export async function fetchTrashedRaindropIds(token: string): Promise<Set<number>> {
+  const trashedIds = new Set<number>();
+  let page = 0;
+
+  while (true) {
+    const response = await request<RaindropsResponse>(token, '/raindrops/-99', {
+      page: String(page),
+      perpage: '50',
+    });
+
+    if (!response.result || response.items.length === 0) {
+      break;
+    }
+
+    for (const item of response.items) {
+      trashedIds.add(item._id);
+    }
+
+    if (response.items.length < 50) {
+      break;
+    }
+
+    page++;
+  }
+
+  return trashedIds;
 }

--- a/src/lib/raindrop-api.ts
+++ b/src/lib/raindrop-api.ts
@@ -1,4 +1,4 @@
-import { RaindropHighlight, HighlightsResponse, RaindropsResponse } from './types';
+import { RaindropHighlight, HighlightsResponse } from './types';
 
 const BASE_URL = 'https://api.raindrop.io/rest/v1';
 
@@ -60,30 +60,16 @@ export async function fetchAllHighlights(token: string): Promise<RaindropHighlig
   return allHighlights;
 }
 
-export async function fetchTrashedRaindropIds(token: string): Promise<Set<number>> {
-  const trashedIds = new Set<number>();
-  let page = 0;
+const TRASH_COLLECTION_ID = -99;
 
-  while (true) {
-    const response = await request<RaindropsResponse>(token, '/raindrops/-99', {
-      page: String(page),
-      perpage: '50',
-    });
-
-    if (!response.result || response.items.length === 0) {
-      break;
-    }
-
-    for (const item of response.items) {
-      trashedIds.add(item._id);
-    }
-
-    if (response.items.length < 50) {
-      break;
-    }
-
-    page++;
+export async function isRaindropTrashed(token: string, raindropId: number): Promise<boolean> {
+  try {
+    const response = await request<{ item: { collection: { $id: number } } }>(
+      token,
+      `/raindrop/${raindropId}`
+    );
+    return response.item.collection.$id === TRASH_COLLECTION_ID;
+  } catch {
+    return false;
   }
-
-  return trashedIds;
 }

--- a/src/lib/raindrop-api.ts
+++ b/src/lib/raindrop-api.ts
@@ -60,6 +60,18 @@ export async function fetchAllHighlights(token: string): Promise<RaindropHighlig
   return allHighlights;
 }
 
+export async function fetchHighlightsForRaindrop(
+  token: string,
+  raindropId: number
+): Promise<RaindropHighlight[]> {
+  try {
+    const response = await request<HighlightsResponse>(token, `/highlights/${raindropId}`);
+    return response.result ? response.items : [];
+  } catch {
+    return [];
+  }
+}
+
 const TRASH_COLLECTION_ID = -99;
 
 export async function isRaindropTrashed(token: string, raindropId: number): Promise<boolean> {

--- a/src/lib/sync-engine.ts
+++ b/src/lib/sync-engine.ts
@@ -1,8 +1,8 @@
 import { RNPlugin } from '@remnote/plugin-sdk';
-import { SETTING_IDS, STORAGE_KEYS } from './constants';
+import { SETTING_IDS, STORAGE_KEYS, IMPORT_LOCATIONS } from './constants';
 import { ArticleWithHighlights, SyncResult } from './types';
 import { fetchAllHighlights } from './raindrop-api';
-import { importArticle } from './rem-creator';
+import { importArticle, moveArticleToCompleted } from './rem-creator';
 
 async function getImportedIds(plugin: RNPlugin): Promise<Set<string>> {
   const stored = await plugin.storage.getSynced<Record<string, boolean>>(STORAGE_KEYS.IMPORTED_IDS);
@@ -16,6 +16,62 @@ async function markAsImported(plugin: RNPlugin, ids: string[]): Promise<void> {
     existing[id] = true;
   }
   await plugin.storage.setSynced(STORAGE_KEYS.IMPORTED_IDS, existing);
+}
+
+async function removeImportedIds(plugin: RNPlugin, ids: string[]): Promise<void> {
+  const existing =
+    (await plugin.storage.getSynced<Record<string, boolean>>(STORAGE_KEYS.IMPORTED_IDS)) || {};
+  for (const id of ids) {
+    delete existing[id];
+  }
+  await plugin.storage.setSynced(STORAGE_KEYS.IMPORTED_IDS, existing);
+}
+
+async function getHighlightArticleMap(plugin: RNPlugin): Promise<Record<string, string>> {
+  return (
+    (await plugin.storage.getSynced<Record<string, string>>(STORAGE_KEYS.HIGHLIGHT_ARTICLE_MAP)) ||
+    {}
+  );
+}
+
+async function updateHighlightArticleMap(
+  plugin: RNPlugin,
+  entries: Record<string, string>
+): Promise<void> {
+  const existing = await getHighlightArticleMap(plugin);
+  Object.assign(existing, entries);
+  await plugin.storage.setSynced(STORAGE_KEYS.HIGHLIGHT_ARTICLE_MAP, existing);
+}
+
+async function removeHighlightArticleEntries(plugin: RNPlugin, ids: string[]): Promise<void> {
+  const existing = await getHighlightArticleMap(plugin);
+  for (const id of ids) {
+    delete existing[id];
+  }
+  await plugin.storage.setSynced(STORAGE_KEYS.HIGHLIGHT_ARTICLE_MAP, existing);
+}
+
+async function getArticleRemMap(plugin: RNPlugin): Promise<Record<string, string>> {
+  return (
+    (await plugin.storage.getSynced<Record<string, string>>(STORAGE_KEYS.ARTICLE_REM_MAP)) || {}
+  );
+}
+
+async function updateArticleRemMap(
+  plugin: RNPlugin,
+  entries: Record<string, string>
+): Promise<void> {
+  const existing = await getArticleRemMap(plugin);
+  Object.assign(existing, entries);
+  await plugin.storage.setSynced(STORAGE_KEYS.ARTICLE_REM_MAP, existing);
+}
+
+async function removeArticleRemEntries(plugin: RNPlugin, urls: string[]): Promise<void> {
+  const existing = await getArticleRemMap(plugin);
+  for (const url of urls) {
+    delete existing[url];
+  }
+  await plugin.storage.setSynced(STORAGE_KEYS.ARTICLE_REM_MAP, existing);
 }
 
 async function setLastSyncTime(plugin: RNPlugin, time: string): Promise<void> {
@@ -60,31 +116,116 @@ function groupHighlightsByArticle(
   return Array.from(articleMap.values());
 }
 
+async function archiveDeletedArticles(
+  plugin: RNPlugin,
+  currentHighlightIds: Set<string>,
+  importedIds: Set<string>
+): Promise<number> {
+  const deletedIds = [...importedIds].filter((id) => !currentHighlightIds.has(id));
+  if (deletedIds.length === 0) return 0;
+
+  const highlightArticleMap = await getHighlightArticleMap(plugin);
+  const articleRemMap = await getArticleRemMap(plugin);
+
+  // Group deleted highlight IDs by article URL
+  const deletedByArticle = new Map<string, string[]>();
+  for (const id of deletedIds) {
+    const articleUrl = highlightArticleMap[id];
+    if (!articleUrl) continue;
+    if (!deletedByArticle.has(articleUrl)) {
+      deletedByArticle.set(articleUrl, []);
+    }
+    deletedByArticle.get(articleUrl)!.push(id);
+  }
+
+  // Check which articles have ALL their highlights deleted
+  const articlesToArchive: string[] = [];
+  for (const [articleUrl, deletedHighlightIds] of deletedByArticle) {
+    // Count how many imported highlights still exist for this article
+    const allArticleHighlightIds = Object.entries(highlightArticleMap)
+      .filter(([, url]) => url === articleUrl)
+      .map(([id]) => id);
+
+    const remainingIds = allArticleHighlightIds.filter((id) => !deletedHighlightIds.includes(id));
+    if (remainingIds.length === 0) {
+      articlesToArchive.push(articleUrl);
+    }
+  }
+
+  let archivedCount = 0;
+  const allDeletedHighlightIds: string[] = [];
+  for (const articleUrl of articlesToArchive) {
+    const remId = articleRemMap[articleUrl];
+    if (!remId) continue;
+
+    try {
+      await moveArticleToCompleted(plugin, remId);
+      archivedCount++;
+    } catch (err) {
+      console.error(`[Raindrop] Failed to archive "${articleUrl}":`, err);
+      continue;
+    }
+
+    // Collect all highlight IDs for this article for cleanup
+    const articleHighlightIds = Object.entries(highlightArticleMap)
+      .filter(([, url]) => url === articleUrl)
+      .map(([id]) => id);
+    allDeletedHighlightIds.push(...articleHighlightIds);
+  }
+
+  // Clean up storage for archived articles
+  if (allDeletedHighlightIds.length > 0) {
+    await removeImportedIds(plugin, allDeletedHighlightIds);
+    await removeHighlightArticleEntries(plugin, allDeletedHighlightIds);
+  }
+  if (articlesToArchive.length > 0) {
+    await removeArticleRemEntries(plugin, articlesToArchive);
+  }
+
+  return archivedCount;
+}
+
 export async function performSync(plugin: RNPlugin): Promise<SyncResult> {
   const token = await plugin.settings.getSetting<string>(SETTING_IDS.API_TOKEN);
   if (!token || !token.trim()) {
-    return { imported: 0, errors: ['No API token configured.'] };
+    return { imported: 0, archived: 0, errors: ['No API token configured.'] };
   }
 
   const allHighlights = await fetchAllHighlights(token);
   const importedIds = await getImportedIds(plugin);
+  const location = await plugin.settings.getSetting<string>(SETTING_IDS.IMPORT_LOCATION);
+
+  // Detect and archive deleted bookmarks (dedicated mode only)
+  let archived = 0;
+  if (location === IMPORT_LOCATIONS.DEDICATED && importedIds.size > 0) {
+    const currentHighlightIds = new Set(allHighlights.map((h) => h._id));
+    archived = await archiveDeletedArticles(plugin, currentHighlightIds, importedIds);
+  }
 
   const newHighlights = allHighlights.filter((h) => !importedIds.has(h._id));
 
   if (newHighlights.length === 0) {
     await setLastSyncTime(plugin, new Date().toISOString());
-    return { imported: 0, errors: [] };
+    return { imported: 0, archived, errors: [] };
   }
 
   const articles = groupHighlightsByArticle(newHighlights);
 
   const importedHighlightIds: string[] = [];
   const errors: string[] = [];
+  const newHighlightArticleEntries: Record<string, string> = {};
+  const newArticleRemEntries: Record<string, string> = {};
 
   for (const article of articles) {
     try {
-      await importArticle(plugin, article);
+      const articleRemId = await importArticle(plugin, article);
       importedHighlightIds.push(...article.highlights.map((h) => h._id));
+
+      // Store mappings for future deletion detection
+      for (const h of article.highlights) {
+        newHighlightArticleEntries[h._id] = article.sourceUrl;
+      }
+      newArticleRemEntries[article.sourceUrl] = articleRemId;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       errors.push(`Failed to import "${article.title}": ${message}`);
@@ -93,10 +234,12 @@ export async function performSync(plugin: RNPlugin): Promise<SyncResult> {
 
   if (importedHighlightIds.length > 0) {
     await markAsImported(plugin, importedHighlightIds);
+    await updateHighlightArticleMap(plugin, newHighlightArticleEntries);
+    await updateArticleRemMap(plugin, newArticleRemEntries);
   }
   await setLastSyncTime(plugin, new Date().toISOString());
 
-  return { imported: importedHighlightIds.length, errors };
+  return { imported: importedHighlightIds.length, archived, errors };
 }
 
 let pollingIntervalId: ReturnType<typeof setInterval> | null = null;

--- a/src/lib/sync-engine.ts
+++ b/src/lib/sync-engine.ts
@@ -1,7 +1,7 @@
 import { RNPlugin } from '@remnote/plugin-sdk';
 import { SETTING_IDS, STORAGE_KEYS, IMPORT_LOCATIONS } from './constants';
 import { ArticleWithHighlights, SyncResult } from './types';
-import { fetchAllHighlights, fetchTrashedRaindropIds } from './raindrop-api';
+import { fetchAllHighlights, isRaindropTrashed } from './raindrop-api';
 import { importArticle, moveArticleToCompleted } from './rem-creator';
 
 async function getImportedIds(plugin: RNPlugin): Promise<Set<string>> {
@@ -91,15 +91,12 @@ async function archiveTrashedBookmarks(
   const trackedRaindropIds = Object.keys(raindropRemMap);
   if (trackedRaindropIds.length === 0) return 0;
 
-  const trashedIds = await fetchTrashedRaindropIds(token);
-  if (trashedIds.size === 0) return 0;
-
-  const toArchive = trackedRaindropIds.filter((id) => trashedIds.has(Number(id)));
-  if (toArchive.length === 0) return 0;
-
   let archivedCount = 0;
   const archivedIds: string[] = [];
-  for (const raindropId of toArchive) {
+  for (const raindropId of trackedRaindropIds) {
+    const trashed = await isRaindropTrashed(token, Number(raindropId));
+    if (!trashed) continue;
+
     const remId = raindropRemMap[raindropId];
     try {
       await moveArticleToCompleted(plugin, remId);

--- a/src/lib/sync-engine.ts
+++ b/src/lib/sync-engine.ts
@@ -1,7 +1,7 @@
 import { RNPlugin } from '@remnote/plugin-sdk';
 import { SETTING_IDS, STORAGE_KEYS, IMPORT_LOCATIONS } from './constants';
 import { ArticleWithHighlights, SyncResult } from './types';
-import { fetchAllHighlights, isRaindropTrashed } from './raindrop-api';
+import { fetchAllHighlights, fetchHighlightsForRaindrop, isRaindropTrashed } from './raindrop-api';
 import { importArticle, moveArticleToCompleted } from './rem-creator';
 
 async function getImportedIds(plugin: RNPlugin): Promise<Set<string>> {
@@ -99,35 +99,27 @@ function groupHighlightsByArticle(
   return Array.from(articleMap.values());
 }
 
-async function archiveTrashedBookmarks(
+interface TrashedBookmark {
+  raindropId: string;
+  remId: string;
+  highlights: import('./types').RaindropHighlight[];
+}
+
+async function detectTrashedBookmarks(
   plugin: RNPlugin,
   token: string
-): Promise<number> {
+): Promise<TrashedBookmark[]> {
   const raindropRemMap = await getRaindropRemMap(plugin);
   const trackedRaindropIds = Object.keys(raindropRemMap);
-  if (trackedRaindropIds.length === 0) return 0;
+  if (trackedRaindropIds.length === 0) return [];
 
-  let archivedCount = 0;
-  const archivedIds: string[] = [];
+  const trashed: TrashedBookmark[] = [];
   for (const raindropId of trackedRaindropIds) {
-    const trashed = await isRaindropTrashed(token, Number(raindropId));
-    if (!trashed) continue;
-
-    const remId = raindropRemMap[raindropId];
-    try {
-      await moveArticleToCompleted(plugin, remId);
-      archivedCount++;
-      archivedIds.push(raindropId);
-    } catch (err) {
-      console.error(`[Raindrop] Failed to archive raindrop ${raindropId}:`, err);
-    }
+    if (!await isRaindropTrashed(token, Number(raindropId))) continue;
+    const highlights = await fetchHighlightsForRaindrop(token, Number(raindropId));
+    trashed.push({ raindropId, remId: raindropRemMap[raindropId], highlights });
   }
-
-  if (archivedIds.length > 0) {
-    await removeRaindropRemEntries(plugin, archivedIds);
-  }
-
-  return archivedCount;
+  return trashed;
 }
 
 export async function performSync(plugin: RNPlugin): Promise<SyncResult> {
@@ -138,27 +130,33 @@ export async function performSync(plugin: RNPlugin): Promise<SyncResult> {
 
   const location = await plugin.settings.getSetting<string>(SETTING_IDS.IMPORT_LOCATION);
 
-  // Detect and archive trashed bookmarks (dedicated mode only)
-  let archived = 0;
+  // Detect trashed bookmarks upfront so we can import their highlights before archiving
+  let trashedBookmarks: TrashedBookmark[] = [];
   if (location === IMPORT_LOCATIONS.DEDICATED) {
-    archived = await archiveTrashedBookmarks(plugin, token);
+    trashedBookmarks = await detectTrashedBookmarks(plugin, token);
   }
 
-  const allHighlights = await fetchAllHighlights(token);
-  const importedIds = await getImportedIds(plugin);
+  const [allHighlights, importedIds] = await Promise.all([
+    fetchAllHighlights(token),
+    getImportedIds(plugin),
+  ]);
 
-  const newHighlights = allHighlights.filter((h) => !importedIds.has(h._id));
+  const trashedHighlights = trashedBookmarks.flatMap((b) => b.highlights);
+  const newHighlights = [...allHighlights, ...trashedHighlights].filter(
+    (h) => !importedIds.has(h._id)
+  );
+
+  const errors: string[] = [];
 
   if (newHighlights.length === 0) {
     await setLastSyncTime(plugin, new Date().toISOString());
-    return { imported: 0, archived, errors: [] };
+    return { imported: 0, archived: 0, errors: [] };
   }
 
   const articles = groupHighlightsByArticle(newHighlights);
   const articleUrlRemMap = await getArticleUrlRemMap(plugin);
 
   const importedHighlightIds: string[] = [];
-  const errors: string[] = [];
   const newRaindropRemEntries: Record<string, string> = {};
   const newArticleUrlRemEntries: Record<string, string> = {};
 
@@ -183,6 +181,23 @@ export async function performSync(plugin: RNPlugin): Promise<SyncResult> {
     await updateRaindropRemMap(plugin, newRaindropRemEntries);
     await updateArticleUrlRemMap(plugin, newArticleUrlRemEntries);
   }
+
+  // Archive trashed bookmarks after their highlights have been imported
+  let archived = 0;
+  const archivedIds: string[] = [];
+  for (const { raindropId, remId } of trashedBookmarks) {
+    try {
+      await moveArticleToCompleted(plugin, remId);
+      archived++;
+      archivedIds.push(raindropId);
+    } catch (err) {
+      console.error(`[Raindrop] Failed to archive raindrop ${raindropId}:`, err);
+    }
+  }
+  if (archivedIds.length > 0) {
+    await removeRaindropRemEntries(plugin, archivedIds);
+  }
+
   await setLastSyncTime(plugin, new Date().toISOString());
 
   return { imported: importedHighlightIds.length, archived, errors };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -25,5 +25,6 @@ export interface ArticleWithHighlights {
 
 export interface SyncResult {
   imported: number;
+  archived: number;
   errors: string[];
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,6 @@
 export interface RaindropHighlight {
   _id: string;
+  raindropRef: number;
   text: string;
   title: string;
   color: string;
@@ -13,6 +14,11 @@ export interface RaindropHighlight {
 export interface HighlightsResponse {
   result: boolean;
   items: RaindropHighlight[];
+}
+
+export interface RaindropsResponse {
+  result: boolean;
+  items: { _id: number }[];
 }
 
 export interface ArticleWithHighlights {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -16,11 +16,6 @@ export interface HighlightsResponse {
   items: RaindropHighlight[];
 }
 
-export interface RaindropsResponse {
-  result: boolean;
-  items: { _id: number }[];
-}
-
 export interface ArticleWithHighlights {
   sourceUrl: string;
   title: string;

--- a/src/widgets/index.tsx
+++ b/src/widgets/index.tsx
@@ -61,12 +61,16 @@ async function onActivate(plugin: ReactRNPlugin) {
       await plugin.app.toast('Syncing Raindrop highlights...');
       try {
         const result = await performSync(plugin);
+        const parts: string[] = [];
+        if (result.imported > 0) parts.push(`imported ${result.imported} highlights`);
+        if (result.archived > 0) parts.push(`archived ${result.archived} article(s)`);
         if (result.errors.length > 0) {
-          await plugin.app.toast(
-            `Imported ${result.imported} highlights with ${result.errors.length} error(s).`
-          );
+          parts.push(`${result.errors.length} error(s)`);
+        }
+        if (parts.length > 0) {
+          await plugin.app.toast(parts.join(', ').replace(/^./, (c) => c.toUpperCase()) + '.');
         } else {
-          await plugin.app.toast(`Imported ${result.imported} new highlights.`);
+          await plugin.app.toast('No new highlights to import.');
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- When using dedicated rem mode, checks each tracked bookmark via `GET /raindrop/{id}` to detect if it was trashed (collection -99)
- When a trashed bookmark matches a previously imported article, moves its Rem to a "Completed" H2 heading inside the Raindrop Articles Rem
- New articles are prepended to the top of the list so they always appear above the Completed section
- A blank separator Rem is added between active articles and the Completed heading
- Stores `raindropRef → remId` and `articleUrl → remId` mappings in synced storage
- Updates toast messages to report archived article count

Closes #8

## Test plan
- [ ] Configure plugin in dedicated rem mode and sync highlights
- [ ] Trash a bookmark in Raindrop.io
- [ ] Re-sync and verify the article moves under a "Completed" heading inside Raindrop Articles
- [ ] Add new highlights to an existing article — verify they append to the existing Rem, not a duplicate
- [ ] Add new highlights after the Completed section exists — verify they appear above it
- [ ] Verify daily document mode is unaffected (no archival behavior)
- [ ] Run `npm run check-types` and `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)