### PR TITLE
feat: show sync errors in right sidebar

### DIFF
--- a/src/lib/sync-engine.ts
+++ b/src/lib/sync-engine.ts
@@ -218,19 +218,19 @@ export function startPolling(plugin: RNPlugin, intervalMinutes: number): void {
         if (result.imported > 0) parts.push(`Imported ${result.imported} highlights`);
         if (result.archived > 0) parts.push(`archived ${result.archived} article(s)`);
         const summary = parts.length > 0 ? parts.join(', ') + '.' : 'Sync completed with errors.';
+        await plugin.app.toast('Raindrop auto-sync completed with errors. Check the Raindrop sidebar tab for details.');
         await plugin.storage.setSession(STORAGE_KEYS.SYNC_STATUS, 'error');
         await plugin.storage.setSession(
           STORAGE_KEYS.SYNC_RESULT,
           `${summary} ${result.errors.length} error(s): ${result.errors[0]}`
         );
-        await plugin.app.toast('Raindrop auto-sync completed with errors. Check the Raindrop sidebar tab for details.');
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       console.error('[Raindrop] Auto-sync error:', err);
+      await plugin.app.toast('Raindrop auto-sync failed. Check the Raindrop sidebar tab for details.');
       await plugin.storage.setSession(STORAGE_KEYS.SYNC_STATUS, 'error');
       await plugin.storage.setSession(STORAGE_KEYS.SYNC_RESULT, `Auto-sync failed: ${message}`);
-      await plugin.app.toast('Raindrop auto-sync failed. Check the Raindrop sidebar tab for details.');
     }
   }, intervalMs);
 }

--- a/src/lib/sync-engine.ts
+++ b/src/lib/sync-engine.ts
@@ -223,14 +223,14 @@ export function startPolling(plugin: RNPlugin, intervalMinutes: number): void {
           STORAGE_KEYS.SYNC_RESULT,
           `${summary} ${result.errors.length} error(s): ${result.errors[0]}`
         );
-        await plugin.app.toast('Auto-sync completed with errors. Check the Raindrop sidebar tab.');
+        await plugin.app.toast('Raindrop auto-sync completed with errors. Check the Raindrop sidebar tab for details.');
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       console.error('[Raindrop] Auto-sync error:', err);
       await plugin.storage.setSession(STORAGE_KEYS.SYNC_STATUS, 'error');
       await plugin.storage.setSession(STORAGE_KEYS.SYNC_RESULT, `Auto-sync failed: ${message}`);
-      await plugin.app.toast('Auto-sync failed. Check the Raindrop sidebar tab for details.');
+      await plugin.app.toast('Raindrop auto-sync failed. Check the Raindrop sidebar tab for details.');
     }
   }, intervalMs);
 }

--- a/src/lib/sync-engine.ts
+++ b/src/lib/sync-engine.ts
@@ -210,10 +210,28 @@ export function startPolling(plugin: RNPlugin, intervalMinutes: number): void {
   if (intervalMinutes <= 0) return;
   const intervalMs = intervalMinutes * 60 * 1000;
 
-  pollingIntervalId = setInterval(() => {
-    performSync(plugin).catch((err) => {
+  pollingIntervalId = setInterval(async () => {
+    try {
+      const result = await performSync(plugin);
+      if (result.errors.length > 0) {
+        const parts: string[] = [];
+        if (result.imported > 0) parts.push(`Imported ${result.imported} highlights`);
+        if (result.archived > 0) parts.push(`archived ${result.archived} article(s)`);
+        const summary = parts.length > 0 ? parts.join(', ') + '.' : 'Sync completed with errors.';
+        await plugin.storage.setSession(STORAGE_KEYS.SYNC_STATUS, 'error');
+        await plugin.storage.setSession(
+          STORAGE_KEYS.SYNC_RESULT,
+          `${summary} ${result.errors.length} error(s): ${result.errors[0]}`
+        );
+        await plugin.app.toast('Auto-sync completed with errors. Check the Raindrop sidebar tab.');
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
       console.error('[Raindrop] Auto-sync error:', err);
-    });
+      await plugin.storage.setSession(STORAGE_KEYS.SYNC_STATUS, 'error');
+      await plugin.storage.setSession(STORAGE_KEYS.SYNC_RESULT, `Auto-sync failed: ${message}`);
+      await plugin.app.toast('Auto-sync failed. Check the Raindrop sidebar tab for details.');
+    }
   }, intervalMs);
 }
 

--- a/src/widgets/index.tsx
+++ b/src/widgets/index.tsx
@@ -1,7 +1,7 @@
 import { declareIndexPlugin, type ReactRNPlugin, WidgetLocation } from '@remnote/plugin-sdk';
 import '../style.css';
 import '../index.css'; // import <widget-name>.css
-import { SETTING_IDS, IMPORT_LOCATIONS } from '../lib/constants';
+import { SETTING_IDS, IMPORT_LOCATIONS, STORAGE_KEYS } from '../lib/constants';
 import { performSync, startPolling, stopPolling } from '../lib/sync-engine';
 
 async function onActivate(plugin: ReactRNPlugin) {
@@ -65,16 +65,29 @@ async function onActivate(plugin: ReactRNPlugin) {
         if (result.imported > 0) parts.push(`imported ${result.imported} highlights`);
         if (result.archived > 0) parts.push(`archived ${result.archived} article(s)`);
         if (result.errors.length > 0) {
-          parts.push(`${result.errors.length} error(s)`);
-        }
-        if (parts.length > 0) {
-          await plugin.app.toast(parts.join(', ').replace(/^./, (c) => c.toUpperCase()) + '.');
+          const summary =
+            parts.length > 0
+              ? parts.join(', ').replace(/^./, (c) => c.toUpperCase()) + '.'
+              : 'Sync completed with errors.';
+          await plugin.storage.setSession(STORAGE_KEYS.SYNC_STATUS, 'error');
+          await plugin.storage.setSession(
+            STORAGE_KEYS.SYNC_RESULT,
+            `${summary} ${result.errors.length} error(s): ${result.errors[0]}`
+          );
+          await plugin.app.toast(`${summary} Check the Raindrop sidebar tab for details.`);
+        } else if (parts.length > 0) {
+          const message = parts.join(', ').replace(/^./, (c) => c.toUpperCase()) + '.';
+          await plugin.storage.setSession(STORAGE_KEYS.SYNC_STATUS, 'idle');
+          await plugin.storage.setSession(STORAGE_KEYS.SYNC_RESULT, message);
+          await plugin.app.toast(message);
         } else {
           await plugin.app.toast('No new highlights to import.');
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        await plugin.app.toast(`Sync failed: ${message}`);
+        await plugin.storage.setSession(STORAGE_KEYS.SYNC_STATUS, 'error');
+        await plugin.storage.setSession(STORAGE_KEYS.SYNC_RESULT, `Sync failed: ${message}`);
+        await plugin.app.toast('Sync failed. Check the Raindrop sidebar tab for details.');
       }
     },
   });

--- a/src/widgets/index.tsx
+++ b/src/widgets/index.tsx
@@ -69,25 +69,25 @@ async function onActivate(plugin: ReactRNPlugin) {
             parts.length > 0
               ? parts.join(', ').replace(/^./, (c) => c.toUpperCase()) + '.'
               : 'Sync completed with errors.';
+          await plugin.app.toast(`${summary} Check the Raindrop sidebar tab for details.`);
           await plugin.storage.setSession(STORAGE_KEYS.SYNC_STATUS, 'error');
           await plugin.storage.setSession(
             STORAGE_KEYS.SYNC_RESULT,
             `${summary} ${result.errors.length} error(s): ${result.errors[0]}`
           );
-          await plugin.app.toast(`${summary} Check the Raindrop sidebar tab for details.`);
         } else if (parts.length > 0) {
           const message = parts.join(', ').replace(/^./, (c) => c.toUpperCase()) + '.';
+          await plugin.app.toast(message);
           await plugin.storage.setSession(STORAGE_KEYS.SYNC_STATUS, 'idle');
           await plugin.storage.setSession(STORAGE_KEYS.SYNC_RESULT, message);
-          await plugin.app.toast(message);
         } else {
           await plugin.app.toast('No new highlights to import.');
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
+        await plugin.app.toast('Sync failed. Check the Raindrop sidebar tab for details.');
         await plugin.storage.setSession(STORAGE_KEYS.SYNC_STATUS, 'error');
         await plugin.storage.setSession(STORAGE_KEYS.SYNC_RESULT, `Sync failed: ${message}`);
-        await plugin.app.toast('Sync failed. Check the Raindrop sidebar tab for details.');
       }
     },
   });

--- a/src/widgets/raindrop_widget.tsx
+++ b/src/widgets/raindrop_widget.tsx
@@ -39,13 +39,14 @@ const RaindropWidget = () => {
     try {
       const result = await performSync(plugin);
       if (result.errors.length > 0) {
-        setSyncResult(
-          `Imported ${result.imported} highlights. ${result.errors.length} error(s): ${result.errors[0]}`
-        );
+        const summary = `Imported ${result.imported} highlight(s). ${result.errors.length} error(s): ${result.errors[0]}`;
+        setSyncResult(summary);
+        setSyncStatus('error');
+        plugin.app.toast('Sync completed with errors. Check the Raindrop sidebar tab for details.');
       } else {
         setSyncResult(`Imported ${result.imported} new highlight(s).`);
+        setSyncStatus('idle');
       }
-      setSyncStatus('idle');
 
       // Restart polling after manual sync with current interval
       const interval = await plugin.settings.getSetting<number>(SETTING_IDS.SYNC_INTERVAL);
@@ -56,6 +57,7 @@ const RaindropWidget = () => {
       const message = err instanceof Error ? err.message : String(err);
       setSyncResult(`Sync failed: ${message}`);
       setSyncStatus('error');
+      plugin.app.toast('Sync failed. Check the Raindrop sidebar tab for details.');
     }
   };
 

--- a/src/widgets/raindrop_widget.tsx
+++ b/src/widgets/raindrop_widget.tsx
@@ -100,7 +100,11 @@ const RaindropWidget = () => {
       </div>
 
       {syncResult && (
-        <div className="text-xs mb-3 p-2 rounded rn-clr-background-light-warning">{syncResult}</div>
+        <div
+          className={`text-xs mb-3 p-2 rounded ${syncStatus === 'error' ? 'rn-clr-background-light-negative' : 'rn-clr-background-light-warning'}`}
+        >
+          {syncResult}
+        </div>
       )}
 
       <button


### PR DESCRIPTION
## Summary

- When a sync error occurs (via command, widget button, or auto-polling), error details are now written to session storage and displayed in the Raindrop sidebar tab
- Toast messages updated to say "Check the Raindrop sidebar tab for details" instead of just showing the raw error or pointing to the console
- Error messages now display with red (`rn-clr-background-light-negative`) styling in the sidebar, while success/info messages keep the yellow warning styling

Closes #9